### PR TITLE
demonstrators.md: integrate PAVICS deployment docs

### DIFF
--- a/docs/demonstrators.md
+++ b/docs/demonstrators.md
@@ -29,7 +29,9 @@ the birdhouse framework.
     [PAVICS](https://ouranosinc.github.io/pavics-sdi/) allowing users to
     perform hydrological modeling and analysis.
 
-[Pavics](https://pavics-sdi.readthedocs.io/en/latest/index.html)
+[Pavics documentation ](https://pavics-sdi.readthedocs.io/en/latest/index.html)
+
+[Pavics deployment](https://birdhouse-deploy.readthedocs.io/en/latest/#birdhouse)
 
 
 ## DACCS


### PR DESCRIPTION
@nilshempelmann my suggestion to link to PAVICS deployment docs instead of migrating the actual documentation here. It would be easier for us to keep the docs and the matching code in-sync if they stay in the same repo.

I also notice there are 2 links for PAVICS documentation: https://pavics-sdi.readthedocs.io/en/latest/index.html and https://ouranosinc.github.io/pavics-sdi/.

I think https://ouranosinc.github.io/pavics-sdi/ is the old one and we should all be using https://pavics-sdi.readthedocs.io/en/latest/index.html.  @Zeitsperre can you confirm?

I can update all the old PAVICS docs link in this PR as well.

Related to https://github.com/bird-house/birdhouse2-docs/issues/8